### PR TITLE
Add a very basic `Makefile` to the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+NPM = npm
+
+vscode: .always
+	cd vscode && $(NPM) run install:all
+	cd vscode && $(NPM) run build
+	cd vscode && $(NPM) run lint
+	cd vscode && $(NPM) test
+
+.always:


### PR DESCRIPTION
Just following the conventions we have in other Sourcemeta projects.
Usually all the projects allow you to just run `make` to do the main
thing.

This is a very quick and dirty version. Maybe we can improve it more.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
