### PR TITLE
Add a new `vscode-open` Makefile target that opens the extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 NPM = npm
+CODE = code
 
 vscode: .always
 	cd vscode && $(NPM) run install:all
 	cd vscode && $(NPM) run build
 	cd vscode && $(NPM) run lint
 	cd vscode && $(NPM) test
+
+vscode-open: .always
+	$(CODE) --extensionDevelopmentPath="$(PWD)/vscode"
 
 .always:


### PR DESCRIPTION
Simpler than doing the F5 thing, mainly if you don't actually use VS
Code.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
