### PR TITLE
Remove the clever `@shared` resolver

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { PanelState } from '@shared/types';
+import type { PanelState } from '../../shared/types.ts';
 import { vscode } from './vscode-api';
 import { FileInfo } from './components/FileInfo';
 import { HealthBar } from './components/HealthBar';

--- a/ui/src/components/FileInfo.tsx
+++ b/ui/src/components/FileInfo.tsx
@@ -1,4 +1,4 @@
-import type { FileInfo as FileInfoType } from '@shared/types';
+import type { FileInfo as FileInfoType } from '../../../shared/types.ts';
 
 export interface FileInfoProps {
   fileInfo: FileInfoType | null;

--- a/ui/src/components/FormatTab.tsx
+++ b/ui/src/components/FormatTab.tsx
@@ -1,4 +1,4 @@
-import type { CommandResult, FileInfo } from '@shared/types';
+import type { CommandResult, FileInfo } from '../../../shared/types.ts';
 import { vscode } from '../vscode-api';
 import { RawOutput } from './RawOutput';
 import { Info, CheckCircle, AlertCircle } from 'lucide-react';

--- a/ui/src/components/HealthBar.tsx
+++ b/ui/src/components/HealthBar.tsx
@@ -1,4 +1,4 @@
-import type { LintResult } from '@shared/types';
+import type { LintResult } from '../../../shared/types.ts';
 
 export interface HealthBarProps {
   lintResult: LintResult;

--- a/ui/src/components/LintTab.tsx
+++ b/ui/src/components/LintTab.tsx
@@ -1,4 +1,4 @@
-import type { LintResult } from '@shared/types';
+import type { LintResult } from '../../../shared/types.ts';
 import { vscode } from '../vscode-api';
 import { RawOutput } from './RawOutput';
 import { CheckCircle, AlertCircle } from 'lucide-react';

--- a/ui/src/components/LoadingSpinner.tsx
+++ b/ui/src/components/LoadingSpinner.tsx
@@ -1,4 +1,4 @@
-import type { FileInfo } from '@shared/types';
+import type { FileInfo } from '../../../shared/types.ts';
 import { AlertTriangle } from 'lucide-react';
 
 export interface LoadingSpinnerProps {

--- a/ui/src/components/MetaschemaTab.tsx
+++ b/ui/src/components/MetaschemaTab.tsx
@@ -1,4 +1,4 @@
-import type { MetaschemaResult, MetaschemaError } from '@shared/types';
+import type { MetaschemaResult, MetaschemaError } from '../../../shared/types.ts';
 import { vscode } from '../vscode-api';
 import { RawOutput } from './RawOutput';
 import { CheckCircle, AlertTriangle } from 'lucide-react';

--- a/ui/src/components/Tabs.tsx
+++ b/ui/src/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import type { PanelState } from '@shared/types';
+import type { PanelState } from '../../../shared/types.ts';
 import type { LucideIcon } from 'lucide-react';
 import { calculateLintStatus, calculateFormatStatus, calculateMetaschemaStatus } from '../utils/tabStatus';
 

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -22,13 +22,7 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-
-    /* Path mapping */
-    "baseUrl": ".",
-    "paths": {
-      "@shared/*": ["../shared/*"]
-    }
+    "noUncheckedSideEffectImports": true
   },
   "include": ["src", "../shared"]
 }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,18 +1,12 @@
 import { defineConfig } from 'vite'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
-import path from 'path'
 
 export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
   ],
-  resolve: {
-    alias: {
-      '@shared': path.resolve(__dirname, '../shared')
-    }
-  },
   build: {
     outDir: 'dist',
     rollupOptions: {

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -14,10 +14,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "paths": {
-      "@shared/*": ["../shared/*"]
-    }
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*", "../shared/**/*"],
   "exclude": ["node_modules", ".vscode-test", "out"]


### PR DESCRIPTION
Just to keep things simpler. I didn't even know this feature existed. I
guess simple and less magic is always better.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
