### PR TITLE
Generate UI built artifacts in `./build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /vscode/.vscode-test
 /vscode/webview-ui/node_modules
 /vscode/webview-ui/dist
+/build

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,9 @@ vscode: .always
 vscode-open: .always
 	$(CODE) --extensionDevelopmentPath="$(PWD)/vscode"
 
+ui: .always
+	cd ui && $(NPM) ci
+	cd ui && $(NPM) run lint
+	cd ui && $(NPM) run build
+
 .always:

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -8,12 +8,18 @@ export default defineConfig({
     tailwindcss(),
   ],
   build: {
-    outDir: 'dist',
+    outDir: '../build/ui',
+    emptyOutDir: true,
     rollupOptions: {
       output: {
-        entryFileNames: 'assets/[name].js',
-        chunkFileNames: 'assets/[name].js',
-        assetFileNames: 'assets/[name].[ext]'
+        entryFileNames: 'app.js',
+        chunkFileNames: '[name].js',
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name === 'index.css') {
+            return 'style.css';
+          }
+          return '[name].[ext]';
+        }
       }
     }
   }

--- a/vscode/src/panel/PanelManager.ts
+++ b/vscode/src/panel/PanelManager.ts
@@ -48,7 +48,7 @@ export class PanelManager {
                 enableScripts: true,
                 retainContextWhenHidden: true,
                 localResourceRoots: [
-                    vscode.Uri.file(path.join(this.extensionPath, '..', 'ui', 'dist'))
+                    vscode.Uri.file(path.join(this.extensionPath, '..', 'build', 'ui'))
                 ]
             }
         );
@@ -100,24 +100,24 @@ export class PanelManager {
      * Get HTML content for the webview (load React build)
      */
     private getHtmlContent(webview: vscode.Webview): string {
-        const distPath = path.join(this.extensionPath, '..', 'ui', 'dist');
+        const distPath = path.join(this.extensionPath, '..', 'build', 'ui');
         const indexPath = path.join(distPath, 'index.html');
 
         let html = fs.readFileSync(indexPath, 'utf-8');
 
         const scriptUri = webview.asWebviewUri(
-            vscode.Uri.file(path.join(distPath, 'assets', 'index.js'))
+            vscode.Uri.file(path.join(distPath, 'app.js'))
         );
         const styleUri = webview.asWebviewUri(
-            vscode.Uri.file(path.join(distPath, 'assets', 'index.css'))
+            vscode.Uri.file(path.join(distPath, 'style.css'))
         );
 
         html = html.replace(
-            /src="\/assets\/index\.js"/g,
+            /src="\/app\.js"/g,
             `src="${scriptUri}"`
         );
         html = html.replace(
-            /href="\/assets\/index\.css"/g,
+            /href="\/style\.css"/g,
             `href="${styleUri}"`
         );
 


### PR DESCRIPTION
I think its nicer to generate files outside the source directory, just
to keep things cleaner. Maybe this also helps us introduce a more
elaborate installation strategy.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
