### PR TITLE
Turn the `Makefile` into the main way of building `webview`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest
             make: make
           - os: windows-latest
-            make: nmake
+            make: make
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
So we consolidate all steps in a single place. Given that the output of
`webview` is a single file, I think we will then be able to do more
smart target based rules.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
