### PR TITLE
Don't run CI on multiple Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ '18.x', '20.x' ]
         platform:
           - os: ubuntu-latest
             make: make
@@ -25,9 +24,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
+      - uses: actions/setup-node@v6
 
       - run: ${{ matrix.platform.make }} webview
 


### PR DESCRIPTION
We are getting warnings about v18 and we would have to keep track of
those warnings every time. Let's just run in latest?

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
