### PR TITLE
Put generated `vscode` files in `build/vscode`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-/vscode/out
 /build

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -1,5 +1,4 @@
 .vscode/**
-.vscode-test/**
 node_modules/**
 .gitignore
 *.vsix

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -11,7 +11,7 @@
     "Other"
   ],
   "activationEvents": [],
-  "main": "./out/vscode/src/extension.js",
+  "main": "../build/vscode/vscode/src/extension.js",
   "contributes": {
     "commands": [
       {

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "ES2020",
-    "outDir": "out",
+    "outDir": "../build/vscode",
     "lib": ["ES2020"],
     "sourceMap": true,
     "strict": true,
@@ -17,5 +17,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*", "../shared/**/*"],
-  "exclude": ["node_modules", "out"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
To continue keeping source directories as clean as possible.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
