### PR TITLE
fix(vscode): wait for extension to be ready to provide a better view

### DIFF
--- a/protocol/types.d.ts
+++ b/protocol/types.d.ts
@@ -49,7 +49,7 @@ export interface PanelState {
   noFileSelected?: boolean;
 }
 
-export type WebviewCommand = 'goToPosition' | 'formatSchema' | 'openExternal';
+export type WebviewCommand = 'goToPosition' | 'formatSchema' | 'openExternal' | 'ready';
 
 export interface WebviewToExtensionMessage {
   command: WebviewCommand;

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -47,8 +47,11 @@ export function activate(context: vscode.ExtensionContext): void {
     });
 
     const openPanelCommand = vscode.commands.registerCommand('sourcemeta-studio.openPanel', () => {
+        const panelAlreadyExists = panelManager.exists();
         panelManager.createOrReveal(context);
-        updatePanelContent();
+        if (panelAlreadyExists) {
+            updatePanelContent();
+        }
     });
 
     const activeEditorChangeListener = vscode.window.onDidChangeActiveTextEditor((editor) => {
@@ -74,7 +77,9 @@ export function activate(context: vscode.ExtensionContext): void {
  * Handle messages from the webview
  */
 function handleWebviewMessage(message: WebviewToExtensionMessage): void {
-    if (message.command === 'goToPosition' && lastActiveTextEditor && message.position) {
+    if (message.command === 'ready') {
+        updatePanelContent();
+    } else if (message.command === 'goToPosition' && lastActiveTextEditor && message.position) {
         const range = errorPositionToRange(message.position);
 
         vscode.window.showTextDocument(lastActiveTextEditor.document, {

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -20,6 +20,8 @@ function App() {
       setActiveTab(savedTab);
     }
 
+    vscode.notifyReady();
+
     // Listen for messages from the extension
     const handleMessage = (event: MessageEvent) => {
       const message = event.data;

--- a/webview/src/vscode-api.ts
+++ b/webview/src/vscode-api.ts
@@ -41,6 +41,10 @@ class VSCodeAPIWrapper {
   public setActiveTab(tab: TabType): void {
     this.vsCodeApi.setState({ activeTab: tab } satisfies WebviewState);
   }
+
+  public notifyReady(): void {
+    this.postMessage({ command: 'ready' });
+  }
 }
 
 export const vscode = new VSCodeAPIWrapper();


### PR DESCRIPTION
Fixes #51 

### Before

Open a file that isn't in the json or yaml format, then open the extension:

<img width="1549" height="1140" alt="Screenshot from 2025-11-13 17-11-09" src="https://github.com/user-attachments/assets/b9b4906c-8fd8-41a0-9f23-fd829fc631e6" />

### After

<img width="1549" height="1140" alt="Screenshot from 2025-11-13 17-13-07" src="https://github.com/user-attachments/assets/524ae7f5-b09c-4313-afc2-40e5a0f6970b" />
