### PR TITLE
fix: show readme in marketplace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ vscode: .always
 	cd vscode && $(NPM) ci
 	cd vscode && $(NPM) run lint
 	cd vscode && $(NPM) run build
-	$(INSTALL) -m 0664 README.markdown build/vscode/README.markdown
+	$(INSTALL) -m 0664 README.markdown build/vscode/README.md
 	$(INSTALL) -m 0664 screenshot.png build/vscode/screenshot.png
 	$(INSTALL) -m 0664 LICENSE build/vscode/LICENSE
 	$(INSTALL) -m 0664 build/webview/index.html build/vscode/index.html


### PR DESCRIPTION
VS code marketplace supports .md files:

<img width="783" height="729" alt="image" src="https://github.com/user-attachments/assets/6d9b9da5-f9fe-4f5b-9d13-8a327a4df269" />

Fixes #47