### PR TITLE
Upgrade JSON Schema CLI to v13.1.0

### DIFF
--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sourcemeta-studio",
       "version": "0.0.5",
       "dependencies": {
-        "@sourcemeta/jsonschema": "^12.8.0"
+        "@sourcemeta/jsonschema": "^13.1.0"
       },
       "devDependencies": {
         "@types/node": "24.x",
@@ -707,9 +707,9 @@
       }
     },
     "node_modules/@sourcemeta/jsonschema": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@sourcemeta/jsonschema/-/jsonschema-12.8.0.tgz",
-      "integrity": "sha512-QowqkEtJb0uZc8YUtI00FfW8pHfSdK+qdlAcrzJuw4Q3HY0nV4B4M3MFtZRFDvdM1XHTmjD7Vsx3Y4+o3PBTjA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@sourcemeta/jsonschema/-/jsonschema-13.1.0.tgz",
+      "integrity": "sha512-jTubqHrW2+bt0bjUcI8TNAIToNKH0T6k54ERoC93+yB2EMgQ2mWMvB2f5eIia/IC4XYOkz5zChWKo5mv09+T+w==",
       "cpu": [
         "x64",
         "arm64"
@@ -721,7 +721,7 @@
         "win32"
       ],
       "bin": {
-        "jsonschema": "cli.js"
+        "jsonschema": "npm/cli.js"
       },
       "engines": {
         "node": ">=16"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -56,7 +56,7 @@
     "lint": "eslint src --ext ts"
   },
   "dependencies": {
-    "@sourcemeta/jsonschema": "^12.8.0"
+    "@sourcemeta/jsonschema": "^13.1.0"
   },
   "devDependencies": {
     "@types/node": "24.x",


### PR DESCRIPTION
- Introduce various linter rules for `title` and `description`
- Extend the linter rule `additional_items_with_schema_items` into
  `non_applicable_additional_items` to cover more cases where
  `additionalItems` is unnecessary
- Add support for the OpenAPI v3.1 and v3.2 base dialects

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
