### PR TITLE
fix#140: ordering of linting errors by source location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "studio",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/test/vscode/package-lock.json
+++ b/test/vscode/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@sourcemeta/studio-test-vscode",
+  "name": "@sourcemeta/studio-tests",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@sourcemeta/studio-test-vscode",
+      "name": "@sourcemeta/studio-tests",
       "version": "0.0.0",
       "devDependencies": {
         "@types/chai": "^5.2.3",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -5,7 +5,7 @@ import { PanelManager } from './panel/PanelManager';
 import { CommandExecutor } from './commands/CommandExecutor';
 import { DiagnosticManager } from './diagnostics/DiagnosticManager';
 import { getFileInfo, parseLintResult, parseMetaschemaResult, errorPositionToRange, parseCliError, hasJsonParseErrors } from './utils/fileUtils';
-import { LintError, PanelState, WebviewToExtensionMessage } from '../../protocol/types';
+import { PanelState, WebviewToExtensionMessage } from '../../protocol/types';
 import { DiagnosticType } from './types';
 
 let panelManager: PanelManager;


### PR DESCRIPTION
Fixes #140 
### **What have been done**

1. The Sourcemeta Studio webview now renders lint diagnostics sorted by source location.
2. e2e test cases written for linting order (lint-order.schema.json).

### **Proof of Action**
<img width="1918" height="1076" alt="image" src="https://github.com/user-attachments/assets/cb545e8e-d3a1-465f-99bc-cdb6c952a398" />

