### PR TITLE
Don't underline the entire schema for top-level errors/warnings

### DIFF
--- a/test/vscode/fixtures/minified-root-lint-schema.json
+++ b/test/vscode/fixtures/minified-root-lint-schema.json
@@ -1,0 +1,1 @@
+{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}

--- a/test/vscode/fixtures/root-only-lint-schema.json
+++ b/test/vscode/fixtures/root-only-lint-schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object"
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
